### PR TITLE
To avoid being overriden by Rocket git's VIM setting

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -30,7 +30,7 @@ zopen_check_results()
 
 zopen_append_to_zoslib_env() {
 cat <<EOF
-VIM|set|PROJECT_ROOT/share/vim/vim90
+VIM|overrideset|PROJECT_ROOT/share/vim/vim90
 ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
 EOF
 }


### PR DESCRIPTION
Use overrideset action instead of set

Noticed by @HarithaIBM in SHARE machine