### PR TITLE
Fix xxd so that it works for ASCII and disable auto-convert on input files

### DIFF
--- a/patches/Makefile.xxd.patch
+++ b/patches/Makefile.xxd.patch
@@ -1,0 +1,13 @@
+diff --git a/src/xxd/Makefile b/src/xxd/Makefile
+index 97bbcc77b..d08af7aa0 100644
+--- a/src/xxd/Makefile
++++ b/src/xxd/Makefile
+@@ -1,7 +1,7 @@
+ # The most simplistic Makefile
+ 
+ xxd: xxd.c
+-	$(CC) $(CFLAGS) $(LDFLAGS) -DUNIX -o xxd xxd.c
++	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -DUNIX -o xxd xxd.c $(LIBS)
+ 
+ clean:
+ 	rm -f xxd xxd.o

--- a/patches/xxd.c.patch
+++ b/patches/xxd.c.patch
@@ -1,0 +1,58 @@
+diff --git a/src/xxd/xxd.c b/src/xxd/xxd.c
+index c90bc027e..4ecab3143 100644
+--- a/src/xxd/xxd.c
++++ b/src/xxd/xxd.c
+@@ -587,13 +587,8 @@ begin_coloring_char (char *l, int *c, int e, int ebcdic)
+     }
+   else  /* ASCII */
+     {
+-      #ifdef __MVS__
+-      if (e >= 64)
+-        l[(*c)++] = COLOR_GREEN;
+-      #else
+       if (e > 31 && e < 127)
+         l[(*c)++] = COLOR_GREEN;
+-      #endif
+ 
+       else if (e == 9 || e == 10 || e == 13)
+         l[(*c)++] = COLOR_YELLOW;
+@@ -905,6 +900,10 @@ main(int argc, char *argv[])
+ 	}
+       rewind(fpo);
+     }
++#ifdef __MVS__
++  // Disable auto-conversion on input file descriptors
++  __disableautocvt(fileno(fp));
++#endif
+ 
+   if (revert)
+     switch (hextype)
+@@ -1066,16 +1065,9 @@ main(int argc, char *argv[])
+ 
+           COLOR_PROLOGUE
+           begin_coloring_char(l,&c,e,ebcdic);
+-#ifdef __MVS__
+-          if (e >= 64)
+-            l[c++] = e;
+-          else
+-            l[c++] = '.';
+-#else
+           if (ebcdic)
+             e = (e < 64) ? '.' : etoa64[e-64];
+           l[c++] = (e > 31 && e < 127) ? e : '.';
+-#endif
+           COLOR_EPILOGUE
+           n++;
+           if (++p == cols)
+@@ -1094,11 +1086,7 @@ main(int argc, char *argv[])
+ 
+           c += addrlen + 3 + p;
+           l[c++] =
+-#ifdef __MVS__
+-              (e >= 64)
+-#else
+               (e > 31 && e < 127)
+-#endif
+               ? e : '.';
+           n++;
+           if (++p == cols)


### PR DESCRIPTION
* Also fixes the ASCII output by removing changes assumed for EBCDIC builds
```
./xxd a.txt
00000000: 4865 6c6c 6f0a                           Hello.
```
* The -E (ebcdic input) option also now works