### PR TITLE
Make bump look for every 100th "release" of vim

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,4 +1,4 @@
-# bump: vim-version /VIM_VERSION="(.*)"/ https://github.com/vim/vim.git|semver:*
+# bump: vim-version /VIM_VERSION="(.*)"/ https://github.com/vim/vim.git|semver:*|n.n.n|/\d00$/
 VIM_VERSION="9.0.2122"
 
 export ZOPEN_BUILD_LINE="DEV"


### PR DESCRIPTION
```shell
 fdra  ~  bump pipeline 'https://github.com/vim/vim.git|semver:*|n.n.n|/\d00$/'
9.0.2100
```

@IgorTodorovskiIBM Once this is merged, can you trigger the bump workflow for this repo?
It should pick up the latest published bump docker image (in which some updates were introduced to support this).